### PR TITLE
Spotify audio problems after breathing

### DIFF
--- a/breathe.sh
+++ b/breathe.sh
@@ -100,6 +100,8 @@ stop_spotify() {
   fi
 
   osascript -e "tell application \"Spotify\" to pause"
+  # reset spotify volume
+  osascript -e "tell application \"Spotify\" to set sound volume to 100"
 }
 
 trap say_goodbye EXIT


### PR DESCRIPTION
Found that I could no longer get sound from Spotify app after running breathe.  Reseting the volume via oascript did the trick. 